### PR TITLE
adding dependencies to metadata to stop warnings

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,4 +8,5 @@
   "project_page": "https://github.com/jolshevski/puppet-env_utils",
   "issues_url": "https://github.com/jolshevski/puppet-env_utils/issues",
   "tags": ["utility", "library", "reflection", "environment", "helpers", "helper", "functions"]
+  "dependencies": [ ]
 }


### PR DESCRIPTION
When using functions from the module you get the following warnings

```
Error: No dependencies module metadata provided for env_utils
Error: No dependencies module metadata provided for env_utils
```